### PR TITLE
Code quality fix - Deprecated elements should have both the annotation and the Javadoc tag.

### DIFF
--- a/src/main/java/io/github/seleniumquery/SeleniumQueryObject.java
+++ b/src/main/java/io/github/seleniumquery/SeleniumQueryObject.java
@@ -511,6 +511,7 @@ public interface SeleniumQueryObject extends Iterable<WebElement> {
 	 * @since 0.9.0
 	 */
 	@SuppressWarnings("unused")
+	@Deprecated
 	SeleniumQueryObject selectOptionByVisibleText(String text);
 
 	/**
@@ -521,6 +522,7 @@ public interface SeleniumQueryObject extends Iterable<WebElement> {
 	 * @since 0.9.0
 	 */
 	@SuppressWarnings("unused")
+	@Deprecated
 	SeleniumQueryObject selectOptionByValue(String value);
 
 	/**

--- a/src/main/java/io/github/seleniumquery/browser/BrowserFunctions.java
+++ b/src/main/java/io/github/seleniumquery/browser/BrowserFunctions.java
@@ -110,6 +110,7 @@ public class BrowserFunctions {
      * @since 0.9.0
      */
     @SuppressWarnings("deprecation")
+    @Deprecated
     public BrowserFunctions pause(long timeToPauseInMillis) {
         LOGGER.debug(format("Pausing for %d milliseconds.", timeToPauseInMillis));
         new org.openqa.selenium.interactions.PauseAction(timeToPauseInMillis).perform();

--- a/src/main/java/io/github/seleniumquery/browser/BrowserFunctionsWithDeprecatedFunctions.java
+++ b/src/main/java/io/github/seleniumquery/browser/BrowserFunctionsWithDeprecatedFunctions.java
@@ -62,6 +62,7 @@ public class BrowserFunctionsWithDeprecatedFunctions extends BrowserFunctions {
 	 * @deprecated This class refers to a deprecated way of accessing some functions and will be removed by the next release.
 	 * You'll find the functions for this object in <b>{@code $.function();}</b> or <b>{@code $.driver().function();}</b>.
 	 */
+	@Deprecated
 	public class OldBrowserFunctions {
 
 		private BrowserFunctionsWithDeprecatedFunctions browser;

--- a/src/main/java/io/github/seleniumquery/by/secondgen/csstree/condition/SQCssConditionImplementedFinders.java
+++ b/src/main/java/io/github/seleniumquery/by/secondgen/csstree/condition/SQCssConditionImplementedFinders.java
@@ -28,6 +28,7 @@ import io.github.seleniumquery.by.secondgen.finder.ElementFinder;
  *
  * @deprecated temporary
  */
+@Deprecated
 public interface SQCssConditionImplementedFinders {
 
     ElementFinder toElementFinder(ElementFinder leftFinder);

--- a/src/main/java/io/github/seleniumquery/by/secondgen/csstree/condition/SQCssConditionImplementedNotYet.java
+++ b/src/main/java/io/github/seleniumquery/by/secondgen/csstree/condition/SQCssConditionImplementedNotYet.java
@@ -17,7 +17,7 @@
 package io.github.seleniumquery.by.secondgen.csstree.condition;
 
 /**
- * This also very is temporary.
+ * @deprecated This also very is temporary.
  * Just used to mark not implemented yet pseudos, so my work to find them is easier.
  */
 @Deprecated

--- a/src/main/java/io/github/seleniumquery/internal/SqObjectFactory.java
+++ b/src/main/java/io/github/seleniumquery/internal/SqObjectFactory.java
@@ -65,6 +65,7 @@ public class SqObjectFactory {
      * @deprecated
      * Don't build with this invalid selector. Construct a {@link SeleniumQueryInvalidBy} yourself, with better selector string.
      */
+    @Deprecated
     public SeleniumQueryObject createWithInvalidSelector(WebDriver driver, List<WebElement> elements, SeleniumQueryObject previous) {
         return create(driver, getNoSelectorInvalidBy(), elements, previous);
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:MissingDeprecatedCheck - Deprecated elements should have both the annotation and the Javadoc tag.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:MissingDeprecatedCheck

Please let me know if you have any questions.

Faisal Hameed