### PR TITLE
Code quality fix - Parsing should be used to convert "Strings" to primitives.

### DIFF
--- a/src/main/java/io/github/seleniumquery/by/firstgen/css/pseudoclasses/EqPseudoClass.java
+++ b/src/main/java/io/github/seleniumquery/by/firstgen/css/pseudoclasses/EqPseudoClass.java
@@ -46,7 +46,7 @@ public class EqPseudoClass implements PseudoClass<ConditionToAllComponent> {
 		if (eqIndex.charAt(0) == '+') {
 			eqIndex = eqIndex.substring(1);
 		}
-		int index = Integer.valueOf(eqIndex);
+		int index = Integer.parseInt(eqIndex);
 		
 		return EqPseudoClass.isEq(driver, element, pseudoClassSelector, index);
 	}
@@ -69,7 +69,7 @@ public class EqPseudoClass implements PseudoClass<ConditionToAllComponent> {
 		if (eqIndex.charAt(0) == '+') {
 			eqIndex = eqIndex.substring(1);
 		}
-		int index = Integer.valueOf(eqIndex);
+		int index = Integer.parseInt(eqIndex);
 		
 		if (index >= 0) {
 			return new ConditionToAllComponent("[position() = " + (index + 1) + "]");

--- a/src/main/java/io/github/seleniumquery/by/firstgen/css/pseudoclasses/GtPseudoClass.java
+++ b/src/main/java/io/github/seleniumquery/by/firstgen/css/pseudoclasses/GtPseudoClass.java
@@ -46,7 +46,7 @@ public class GtPseudoClass implements PseudoClass<ConditionToAllComponent> {
 		if (gtIndex.charAt(0) == '+') {
 			gtIndex = gtIndex.substring(1);
 		}
-		int index = Integer.valueOf(gtIndex);
+		int index = Integer.parseInt(gtIndex);
 		
 		return GtPseudoClass.isGt(driver, element, pseudoClassSelector, index);
 	}
@@ -82,7 +82,7 @@ public class GtPseudoClass implements PseudoClass<ConditionToAllComponent> {
 		if (eqIndex.charAt(0) == '+') {
 			eqIndex = eqIndex.substring(1);
 		}
-		int index = Integer.valueOf(eqIndex);
+		int index = Integer.parseInt(eqIndex);
 		
 		if (index >= 0) {
 			return new ConditionToAllComponent("[position() > " + (index + 1) + "]");

--- a/src/main/java/io/github/seleniumquery/by/firstgen/css/pseudoclasses/LtPseudoClass.java
+++ b/src/main/java/io/github/seleniumquery/by/firstgen/css/pseudoclasses/LtPseudoClass.java
@@ -46,7 +46,7 @@ public class LtPseudoClass implements PseudoClass<ConditionToAllComponent> {
 		if (ltIndex.charAt(0) == '+') {
 			ltIndex = ltIndex.substring(1);
 		}
-		int index = Integer.valueOf(ltIndex);
+		int index = Integer.parseInt(ltIndex);
 		
 		return LtPseudoClass.isLt(driver, element, pseudoClassSelector, index);
 	}
@@ -85,7 +85,7 @@ public class LtPseudoClass implements PseudoClass<ConditionToAllComponent> {
 		if (eqIndex.charAt(0) == '+') {
 			eqIndex = eqIndex.substring(1);
 		}
-		int index = Integer.valueOf(eqIndex);
+		int index = Integer.parseInt(eqIndex);
 		
 		if (index >= 0) {
 			return new ConditionToAllComponent("[position() < " + (index + 1) + "]");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2130 - Parsing should be used to convert "Strings" to primitives.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2130

Please let me know if you have any questions.

Faisal Hameed