### PR TITLE
Code quality fix - The members of an interface declaration or class should appear in a pre-defined order.

### DIFF
--- a/src/main/java/io/github/seleniumquery/SeleniumQueryConfig.java
+++ b/src/main/java/io/github/seleniumquery/SeleniumQueryConfig.java
@@ -45,6 +45,8 @@ public class SeleniumQueryConfig {
 	private static long waitUntilTimeout = 10001;
 	private static long waitUntilPollingInterval = 901;
 	
+	private static Properties properties;
+	
 	static {
 		loadPropertiesFiles();
 	}
@@ -82,8 +84,6 @@ public class SeleniumQueryConfig {
 		}
 		return Long.valueOf(propertyAsString);
 	}
-	
-	private static Properties properties;
 	
 	public static String get(String property) {
 		return properties.getProperty(property);

--- a/src/main/java/io/github/seleniumquery/by/SeleniumQueryBy.java
+++ b/src/main/java/io/github/seleniumquery/by/SeleniumQueryBy.java
@@ -38,6 +38,8 @@ public class SeleniumQueryBy extends By {
 	private static final String STARTING_BRACES = "(\\s*\\(\\s*)*";
 	private static final String XPATH_AXES = "ancestor|ancestor-or-self|attribute|child|descendant|descendant-or-self|following|following-sibling|parent|preceding|preceding-sibling|self";
 	private static final Pattern XPATH_EXPRESSION_PATTERN = Pattern.compile(STARTING_BRACES + "(/|(" + XPATH_AXES + ")::).*");
+	
+	private final String selector;
 
 	/**
 	 * Enhanced selector is not just the CSS selector, it also supports XPath expressions and some
@@ -51,8 +53,6 @@ public class SeleniumQueryBy extends By {
 	public static SeleniumQueryBy byEnhancedSelector(String selector) {
 		return new SeleniumQueryBy(selector);
 	}
-
-	private final String selector;
 
 	
 	/**

--- a/src/main/java/io/github/seleniumquery/by/common/elementfilter/ElementFilterList.java
+++ b/src/main/java/io/github/seleniumquery/by/common/elementfilter/ElementFilterList.java
@@ -36,10 +36,6 @@ import static java.util.Arrays.asList;
  */
 public class ElementFilterList {
 
-    public static ElementFilterList asFilterList(ElementFilter... filters) {
-        return new ElementFilterList(asList(filters));
-    }
-
     public static final ElementFilterList FILTER_NOTHING_LIST = new ElementFilterList(Collections.<ElementFilter>emptyList()) {
         @Override
         public List<WebElement> filter(WebDriver driver, List<WebElement> elements) {
@@ -60,6 +56,11 @@ public class ElementFilterList {
 	public ElementFilterList(List<ElementFilter> elementFilters) {
 		this.elementFilters = Collections.unmodifiableList(elementFilters);
 	}
+	
+
+    public static ElementFilterList asFilterList(ElementFilter... filters) {
+        return new ElementFilterList(asList(filters));
+    }
 
 	public List<WebElement> filter(SearchContext context, List<WebElement> elements) {
 		WebDriver driver = SelectorUtils.getWebDriver(context);

--- a/src/main/java/io/github/seleniumquery/by/common/preparser/CssSelectorParser.java
+++ b/src/main/java/io/github/seleniumquery/by/common/preparser/CssSelectorParser.java
@@ -30,6 +30,8 @@ public class CssSelectorParser {
 	private static final Log LOGGER = LogFactory.getLog(CssSelectorParser.class);
 
 	private static final NotEqualsAttributeSelectorFix NOT_EQUALS_ATTRIBUTE_SELECTOR_FIX = new NotEqualsAttributeSelectorFix();
+	
+	private static final SACParserCSS3 SAC_CSS3_PARSER = new SACParserCSS3();
 
 	public static CssParsedSelectorList parseSelector(String selector) {
         PreParsedSelector preParsedSelector = preParseSelector(selector);
@@ -52,8 +54,6 @@ public class CssSelectorParser {
             throw new SeleniumQueryException("Impossible to parse selector \""+selector+"\": "+e.getMessage(), e);
         }
 	}
-
-	private static final SACParserCSS3 SAC_CSS3_PARSER = new SACParserCSS3();
 
     static {
 	    SAC_CSS3_PARSER.setErrorHandler(new ErrorHandler() {

--- a/src/main/java/io/github/seleniumquery/by/common/preparser/CssSelectorPreParser.java
+++ b/src/main/java/io/github/seleniumquery/by/common/preparser/CssSelectorPreParser.java
@@ -39,10 +39,6 @@ import static java.lang.Character.isLetter;
  */
 class CssSelectorPreParser {
 
-    static PreParsedSelector transformSelector(String selector) {
-        return new CssSelectorPreParser(selector).transformSelector();
-    }
-
 	static class PreParsedSelector {
 		private String transformedSelector;
 		private ArgumentMap argumentMap;
@@ -60,6 +56,10 @@ class CssSelectorPreParser {
 	private int selectorCurrentParsingIndex;
 	private StringBuilder transformedSelector;
 	private Map<Integer, String> argumentMap;
+	
+    static PreParsedSelector transformSelector(String selector) {
+        return new CssSelectorPreParser(selector).transformSelector();
+    }
 
     private CssSelectorPreParser(String selector) {
         this.selector = selector;

--- a/src/main/java/io/github/seleniumquery/by/firstgen/css/pseudoclasses/EnabledPseudoClass.java
+++ b/src/main/java/io/github/seleniumquery/by/firstgen/css/pseudoclasses/EnabledPseudoClass.java
@@ -43,6 +43,12 @@ public class EnabledPseudoClass implements PseudoClass<ConditionSimpleComponent>
 	private static final String OPTION_TAG = "option";
 	public static final List<String> ENABLEABLE_TAGS = DisabledPseudoClass.DISABLEABLE_TAGS;
 	
+	public static final String ENABLED_XPATH = "(" +
+            DisabledPseudoClass.DISABLEABLE_TAGS_XPATH +
+        " and " +
+		    "not("+ DisabledPseudoClass.DISABLED_XPATH_CONDITION+")" +
+        ")";
+	
 	@Override
 	public boolean isApplicable(String pseudoClassValue) {
 		return ENABLED_PSEUDO_CLASS_NO_COLON.equals(pseudoClassValue);
@@ -63,11 +69,6 @@ public class EnabledPseudoClass implements PseudoClass<ConditionSimpleComponent>
 		return element.isEnabled() && ENABLEABLE_TAGS.contains(element.getTagName());
 	}
 	
-	public static final String ENABLED_XPATH = "(" +
-                DisabledPseudoClass.DISABLEABLE_TAGS_XPATH +
-            " and " +
-			    "not("+ DisabledPseudoClass.DISABLED_XPATH_CONDITION+")" +
-            ")";
 	
 	@Override
 	public ConditionSimpleComponent pseudoClassToXPath(PseudoClassSelector pseudoClassSelector) {

--- a/src/main/java/io/github/seleniumquery/by/firstgen/css/pseudoclasses/FocusablePseudoClass.java
+++ b/src/main/java/io/github/seleniumquery/by/firstgen/css/pseudoclasses/FocusablePseudoClass.java
@@ -46,6 +46,28 @@ class FocusablePseudoClass implements PseudoClass<ConditionSimpleComponent> {
 	
 	private static final String FOCUSABLE_PSEUDO_CLASS_NO_COLON = "focusable";
 	
+	private final ElementFilter focusablePseudoClassFilter = new PseudoClassFilter(this);
+
+	// //button[.='OK' and not(ancestor::div[contains(@style,'display:none')]) and ]
+	
+	
+	// upon changing the expression below, check also the one at :tabbable
+	static final String FOCUSABLE_XPATH =
+		// is visible and...
+		" ("
+			+ " ("
+				+ " (local-name() = 'input' or local-name() = 'button' or local-name() = 'optgroup' or local-name() = 'option' or local-name() = 'select' or local-name() = 'textarea')"
+				+ " and "
+				+ EnabledPseudoClass.ENABLED_XPATH
+			+ " ) "
+			+ " or "
+			+ " (local-name() = 'a' and @href) "
+			+ " or "
+			+ " (local-name() = 'area' and @href)"
+			+ " or "
+			+ " @tabindex"
+		+ ")";
+	
 	@Override
 	public boolean isApplicable(String pseudoClassValue) {
 		return FOCUSABLE_PSEUDO_CLASS_NO_COLON.equals(pseudoClassValue);
@@ -68,28 +90,6 @@ class FocusablePseudoClass implements PseudoClass<ConditionSimpleComponent> {
 		}
 		return element.getAttribute("tabindex") != null;
 	}
-	
-	private final ElementFilter focusablePseudoClassFilter = new PseudoClassFilter(this);
-
-	// //button[.='OK' and not(ancestor::div[contains(@style,'display:none')]) and ]
-	
-	
-	// upon changing the expression below, check also the one at :tabbable
-	static final String FOCUSABLE_XPATH =
-		// is visible and...
-		" ("
-			+ " ("
-				+ " (local-name() = 'input' or local-name() = 'button' or local-name() = 'optgroup' or local-name() = 'option' or local-name() = 'select' or local-name() = 'textarea')"
-				+ " and "
-				+ EnabledPseudoClass.ENABLED_XPATH
-			+ " ) "
-			+ " or "
-			+ " (local-name() = 'a' and @href) "
-			+ " or "
-			+ " (local-name() = 'area' and @href)"
-			+ " or "
-			+ " @tabindex"
-		+ ")";
 	
 	@Override
 	public ConditionSimpleComponent pseudoClassToXPath(PseudoClassSelector pseudoClassSelector) {

--- a/src/main/java/io/github/seleniumquery/by/firstgen/css/pseudoclasses/PseudoClassOnlySupportedThroughIsOrFilterException.java
+++ b/src/main/java/io/github/seleniumquery/by/firstgen/css/pseudoclasses/PseudoClassOnlySupportedThroughIsOrFilterException.java
@@ -34,10 +34,6 @@ package io.github.seleniumquery.by.firstgen.css.pseudoclasses;
  */
 public class PseudoClassOnlySupportedThroughIsOrFilterException extends RuntimeException {
 
-    static void pseudoClassNotSupportedWhenUsedDirectly(String pseudoClass) {
-        throw new PseudoClassOnlySupportedThroughIsOrFilterException(pseudoClass);
-    }
-
     private PseudoClassOnlySupportedThroughIsOrFilterException(String pseudoClass) {
         super(String.format(
                 "Direct use of this pseudo-class is not supported.\n" +
@@ -47,6 +43,10 @@ public class PseudoClassOnlySupportedThroughIsOrFilterException extends RuntimeE
                 "\t\tUSE: $(\"my-selector\").filter(\":%s\").\n" +
                 "\tUsing .is() is also supported: $(\"my-selector\").is(\":%s\")\n",
                 pseudoClass, pseudoClass, pseudoClass, pseudoClass));
+    }
+    
+    static void pseudoClassNotSupportedWhenUsedDirectly(String pseudoClass) {
+        throw new PseudoClassOnlySupportedThroughIsOrFilterException(pseudoClass);
     }
 
 }

--- a/src/main/java/io/github/seleniumquery/by/firstgen/xpath/component/AdjacentComponent.java
+++ b/src/main/java/io/github/seleniumquery/by/firstgen/xpath/component/AdjacentComponent.java
@@ -26,15 +26,15 @@ package io.github.seleniumquery.by.firstgen.xpath.component;
  */
 public class AdjacentComponent extends XPathComponent {
 
+    private AdjacentComponent(TagComponent other) {
+        super(other.xPathExpression, other.combinatedComponents, other.elementFilterList);
+    }
+    
     public static TagComponent combine(TagComponent one, TagComponent other) {
         AdjacentComponent otherCopyWithModifiedType = new AdjacentComponent(other);
         return new TagComponent(one.xPathExpression,
                                 ComponentUtils.joinComponents(one.combinatedComponents, otherCopyWithModifiedType),
                                 ComponentUtils.joinFilters(one.elementFilterList, otherCopyWithModifiedType));
-    }
-
-    private AdjacentComponent(TagComponent other) {
-        super(other.xPathExpression, other.combinatedComponents, other.elementFilterList);
     }
 
     @Override

--- a/src/main/java/io/github/seleniumquery/by/firstgen/xpath/component/DescendantDirectComponent.java
+++ b/src/main/java/io/github/seleniumquery/by/firstgen/xpath/component/DescendantDirectComponent.java
@@ -23,15 +23,16 @@ import io.github.seleniumquery.by.firstgen.xpath.UnsupportedConditionalSelector;
  */
 public class DescendantDirectComponent extends XPathComponent {
 
+
+    private DescendantDirectComponent(TagComponent other) {
+        super(other.xPathExpression, other.combinatedComponents, other.elementFilterList);
+    }
+    
     public static TagComponent combine(TagComponent one, TagComponent other) {
         DescendantDirectComponent otherCopyWithModifiedType = new DescendantDirectComponent(other);
         return new TagComponent(one.xPathExpression,
                                 ComponentUtils.joinComponents(one.combinatedComponents, otherCopyWithModifiedType),
                                 ComponentUtils.joinFilters(one.elementFilterList, otherCopyWithModifiedType));
-    }
-
-    private DescendantDirectComponent(TagComponent other) {
-        super(other.xPathExpression, other.combinatedComponents, other.elementFilterList);
     }
 
     @Override

--- a/src/main/java/io/github/seleniumquery/by/firstgen/xpath/component/DescendantGeneralComponent.java
+++ b/src/main/java/io/github/seleniumquery/by/firstgen/xpath/component/DescendantGeneralComponent.java
@@ -23,15 +23,15 @@ import io.github.seleniumquery.by.firstgen.xpath.UnsupportedConditionalSelector;
  */
 public class DescendantGeneralComponent extends XPathComponent {
 
+    private DescendantGeneralComponent(TagComponent other) {
+        super(other.xPathExpression, other.combinatedComponents, other.elementFilterList);
+    }
+    
     public static TagComponent combine(TagComponent one, TagComponent other) {
         DescendantGeneralComponent otherCopyWithModifiedType = new DescendantGeneralComponent(other);
         return new TagComponent(one.xPathExpression,
                                 ComponentUtils.joinComponents(one.combinatedComponents, otherCopyWithModifiedType),
                                 ComponentUtils.joinFilters(one.elementFilterList, otherCopyWithModifiedType));
-    }
-
-    private DescendantGeneralComponent(TagComponent other) {
-        super(other.xPathExpression, other.combinatedComponents, other.elementFilterList);
     }
 
     @Override

--- a/src/main/java/io/github/seleniumquery/by/firstgen/xpath/component/special/IdConditionComponent.java
+++ b/src/main/java/io/github/seleniumquery/by/firstgen/xpath/component/special/IdConditionComponent.java
@@ -43,13 +43,13 @@ public class IdConditionComponent extends ConditionSimpleComponent {
         this.wantedId = id;
     }
 
-    private static String idXpath(String id) {
-        return "[@id = " + intoEscapedXPathString(id) + "]";
-    }
-
     private IdConditionComponent(String id, List<XPathComponent> combinatedComponents, ElementFilterList elementFilterList) {
         super(idXpath(id), combinatedComponents, elementFilterList);
         this.wantedId = id;
+    }
+
+    private static String idXpath(String id) {
+        return "[@id = " + intoEscapedXPathString(id) + "]";
     }
 
     public List<WebElement> findWebElements(SearchContext context) {

--- a/src/main/java/io/github/seleniumquery/by/secondgen/csstree/condition/pseudoclass/basicfilter/SQCssNotPseudoClass.java
+++ b/src/main/java/io/github/seleniumquery/by/secondgen/csstree/condition/pseudoclass/basicfilter/SQCssNotPseudoClass.java
@@ -41,10 +41,6 @@ public class SQCssNotPseudoClass extends SQCssFunctionalPseudoClassCondition {
        but we still match it, so we can return a proper error message */
     public static final String PSEUDO_PURE_NOT = "not";
 
-    public SQCssNotPseudoClass(PseudoClass pseudoClassSelector) {
-        super(pseudoClassSelector);
-    }
-
     public MaybeNativelySupportedPseudoClass notPseudoClassFinderFactoryStrategy = new MaybeNativelySupportedPseudoClass() {
         @Override
         public String pseudoClassForCSSNativeSupportCheck(WebDriver webDriver) {
@@ -86,6 +82,10 @@ public class SQCssNotPseudoClass extends SQCssFunctionalPseudoClassCondition {
             return XPathAndFilterFinder.pureXPath("not("+joinedXPathExps+")");
         }
     };
+    
+    public SQCssNotPseudoClass(PseudoClass pseudoClassSelector) {
+        super(pseudoClassSelector);
+    }
 
     @Override
     public MaybeNativelySupportedPseudoClass getElementFinderFactoryStrategy() {

--- a/src/main/java/io/github/seleniumquery/by/secondgen/csstree/condition/pseudoclass/contentfilter/SQCssContainsPseudoClass.java
+++ b/src/main/java/io/github/seleniumquery/by/secondgen/csstree/condition/pseudoclass/contentfilter/SQCssContainsPseudoClass.java
@@ -34,10 +34,6 @@ public class SQCssContainsPseudoClass extends SQCssFunctionalPseudoClassConditio
 
     public static final String PSEUDO = "contains";
 
-    public SQCssContainsPseudoClass(PseudoClass pseudoClassSelector) {
-        super(pseudoClassSelector);
-    }
-
     public NeverNativelySupportedPseudoClass containsPseudoClassFinderFactoryStrategy = new NeverNativelySupportedPseudoClass() {
         @Override
         public XPathAndFilterFinder toXPath(WebDriver webDriver) {
@@ -47,6 +43,10 @@ public class SQCssContainsPseudoClass extends SQCssFunctionalPseudoClassConditio
             return XPathAndFilterFinder.pureXPath("contains(string(.), " + wantedTextToContain + ")");
         }
     };
+
+    public SQCssContainsPseudoClass(PseudoClass pseudoClassSelector) {
+        super(pseudoClassSelector);
+    }
 
     @Override
     public NeverNativelySupportedPseudoClass getElementFinderFactoryStrategy() {

--- a/src/main/java/io/github/seleniumquery/internal/SqObjectFactory.java
+++ b/src/main/java/io/github/seleniumquery/internal/SqObjectFactory.java
@@ -39,6 +39,11 @@ import static java.util.Arrays.asList;
 public class SqObjectFactory {
 
     private static SqObjectFactory instance;
+    private final SeleniumQueryFunctions seleniumQueryFunctions;
+
+    public SqObjectFactory(SeleniumQueryFunctions seleniumQueryFunctions) {
+        this.seleniumQueryFunctions = seleniumQueryFunctions;
+    }
 
     public static SqObjectFactory instance() {
         if (instance == null) {
@@ -46,12 +51,6 @@ public class SqObjectFactory {
         }
         return instance;
     }
-
-    public SqObjectFactory(SeleniumQueryFunctions seleniumQueryFunctions) {
-        this.seleniumQueryFunctions = seleniumQueryFunctions;
-    }
-
-    private final SeleniumQueryFunctions seleniumQueryFunctions;
 
     public SeleniumQueryObject create(WebDriver driver, By by, List<WebElement> elements, SeleniumQueryObject previous) {
         return create(this.seleniumQueryFunctions, driver, by, elements, previous);

--- a/src/main/java/io/github/seleniumquery/utils/DriverVersionUtils.java
+++ b/src/main/java/io/github/seleniumquery/utils/DriverVersionUtils.java
@@ -41,6 +41,10 @@ public class DriverVersionUtils {
 
 	private static DriverVersionUtils instance = new DriverVersionUtils();
 
+	private static final Log LOGGER = LogFactory.getLog(DriverVersionUtils.class);
+	
+	private Map<WebDriver, Map<String, Boolean>> driverSupportedPseudos = new HashMap<>();
+
 	public static DriverVersionUtils getInstance() {
 		return instance;
 	}
@@ -49,10 +53,6 @@ public class DriverVersionUtils {
 	public static void overrideSingletonInstance(DriverVersionUtils instance) {
 		DriverVersionUtils.instance = instance;
 	}
-
-	private static final Log LOGGER = LogFactory.getLog(DriverVersionUtils.class);
-	
-	private Map<WebDriver, Map<String, Boolean>> driverSupportedPseudos = new HashMap<>();
 	
 	public boolean hasNativeSupportForPseudo(WebDriver driver, String pseudoClass) {
 		Map<String, Boolean> driverMap = getDriverMap(driver);

--- a/src/main/java/io/github/seleniumquery/wait/WaitingBehaviorModifier.java
+++ b/src/main/java/io/github/seleniumquery/wait/WaitingBehaviorModifier.java
@@ -23,15 +23,15 @@ public enum WaitingBehaviorModifier {
 
     private final String toString;
 
+    WaitingBehaviorModifier(String toString) {
+        this.toString = toString;
+    }
+
     public static WaitingBehaviorModifier fromBoolean(boolean negated) {
         if (negated) {
             return NEGATED_BEHAVIOR;
         }
         return USUAL_BEHAVIOR;
-    }
-
-    WaitingBehaviorModifier(String toString) {
-        this.toString = toString;
     }
 
     @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.

Faisal Hameed