### PR TITLE
Code quality fix - "@Override" annotation should be used on any method overriding.

### DIFF
--- a/src/main/java/io/github/seleniumquery/by/common/preparser/CssSelectorParser.java
+++ b/src/main/java/io/github/seleniumquery/by/common/preparser/CssSelectorParser.java
@@ -57,14 +57,17 @@ public class CssSelectorParser {
 
     static {
 	    SAC_CSS3_PARSER.setErrorHandler(new ErrorHandler() {
+	    	@Override
 			public void warning(final CSSParseException cssParseException) throws CSSException {
 				LOGGER.warn(cssParseException.toString(), cssParseException);
 			}
 
+	    	@Override
 			public void error(final CSSParseException cssParseException) throws CSSException {
 				throw cssParseException;
 			}
 
+	    	@Override
 			public void fatalError(final CSSParseException cssParseException) throws CSSException {
 				throw cssParseException;
 			}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1161 - "@Override" annotation should be used on any method overriding.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1161

Please let me know if you have any questions.

Faisal Hameed