### PR TITLE
Code quality fix - Subclasses that add fields should override "equals". 

### DIFF
--- a/src/main/java/io/github/seleniumquery/by/SeleniumQueryBy.java
+++ b/src/main/java/io/github/seleniumquery/by/SeleniumQueryBy.java
@@ -106,5 +106,32 @@ public class SeleniumQueryBy extends By {
 	public String getSelector() {
 		return this.selector;
 	}
+
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + ((selector == null) ? 0 : selector.hashCode());
+		return result;
+	}
+
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (!super.equals(obj))
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		SeleniumQueryBy other = (SeleniumQueryBy) obj;
+		if (selector == null) {
+			if (other.selector != null)
+				return false;
+		} else if (!selector.equals(other.selector))
+			return false;
+		return true;
+	}
 	
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2160 - Subclasses that add fields should override "equals". 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2160

Please let me know if you have any questions.

Faisal Hameed