### PR TITLE
Code quality fix - Strings literals should be placed on the left side when checking for equality.

### DIFF
--- a/src/main/java/io/github/seleniumquery/by/firstgen/css/combinators/DirectDescendantCssSelector.java
+++ b/src/main/java/io/github/seleniumquery/by/firstgen/css/combinators/DirectDescendantCssSelector.java
@@ -39,7 +39,7 @@ public class DirectDescendantCssSelector implements CssSelector<DescendantSelect
 	public boolean is(WebDriver driver, WebElement element, ArgumentMap argumentMap, DescendantSelector descendantSelector) {
 		WebElement parent = SelectorUtils.parent(element);
 		//noinspection SimplifiableIfStatement
-		if (parent == null || parent.getTagName().equals("html")) {
+		if (parent == null || "html".equals(parent.getTagName())) {
 			return false;
 		}
 		return elementMatchesDescendantSelector(driver, element, descendantSelector, argumentMap)

--- a/src/main/java/io/github/seleniumquery/by/firstgen/css/pseudoclasses/FocusablePseudoClass.java
+++ b/src/main/java/io/github/seleniumquery/by/firstgen/css/pseudoclasses/FocusablePseudoClass.java
@@ -81,11 +81,11 @@ class FocusablePseudoClass implements PseudoClass<ConditionSimpleComponent> {
 		if (DisabledPseudoClass.DISABLEABLE_TAGS.contains(element.getTagName())) {
 			return element.isEnabled();
 		}
-		if (element.getTagName().equals("a") && element.getAttribute("href") != null) {
+		if ("a".equals(element.getTagName()) && element.getAttribute("href") != null) {
 			return true;
 		}
 		//noinspection SimplifiableIfStatement
-		if (element.getTagName().equals("area") && element.getAttribute("href") != null /* && inside a named map */ /* && there is a visible image using the map */) {
+		if ("area".equals(element.getTagName()) && element.getAttribute("href") != null /* && inside a named map */ /* && there is a visible image using the map */) {
 			return true;
 		}
 		return element.getAttribute("tabindex") != null;

--- a/src/main/java/io/github/seleniumquery/by/firstgen/css/pseudoclasses/OnlyChildPseudoClass.java
+++ b/src/main/java/io/github/seleniumquery/by/firstgen/css/pseudoclasses/OnlyChildPseudoClass.java
@@ -41,9 +41,9 @@ public class OnlyChildPseudoClass implements PseudoClass<ConditionSimpleComponen
 		WebElement parent = SelectorUtils.parent(element);
 		//noinspection SimplifiableIfStatement
 		if (parent == null // parent is null when element is <HTML>
-				|| parent.getTagName().equals("html")
-				|| parent.getTagName().equals("body")
-				|| parent.getTagName().equals("head")) {
+				|| "html".equals(parent.getTagName())
+				|| "body".equals(parent.getTagName())
+				|| "head".equals(parent.getTagName())) {
 			// I have tested and :only-child never worked direct children of those
 			return false;
 		}

--- a/src/main/java/io/github/seleniumquery/by/firstgen/css/pseudoclasses/RootPseudoClass.java
+++ b/src/main/java/io/github/seleniumquery/by/firstgen/css/pseudoclasses/RootPseudoClass.java
@@ -37,7 +37,7 @@ public class RootPseudoClass implements PseudoClass<ConditionSimpleComponent> {
 	
 	@Override
 	public boolean isPseudoClass(WebDriver driver, WebElement element, PseudoClassSelector pseudoClassSelector) {
-		return element.getTagName().equals("html");
+		return "html".equals(element.getTagName());
 	}
 	
 	@Override

--- a/src/main/java/io/github/seleniumquery/by/firstgen/xpath/component/TagComponent.java
+++ b/src/main/java/io/github/seleniumquery/by/firstgen/xpath/component/TagComponent.java
@@ -57,7 +57,7 @@ public class TagComponent extends XPathComponent implements Combinable<TagCompon
     private boolean canUseById() {
         //noinspection PointlessBooleanExpression,ConstantConditions
         return ID_OPTIMIZATION
-                && this.xPathExpression.equals("*")
+                && "*".equals(this.xPathExpression)
                 && this.combinatedComponents.size() == 1
                 && this.combinatedComponents.get(0) instanceof IdConditionComponent;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1132 - Strings literals should be placed on the left side when checking for equality.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1132

Please let me know if you have any questions.

Faisal Hameed