### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/main/java/io/github/seleniumquery/SeleniumQuery.java
+++ b/src/main/java/io/github/seleniumquery/SeleniumQuery.java
@@ -80,6 +80,8 @@ public class SeleniumQuery {
 	 * <p>The seleniumQuery global browser functions object.</p> This works as an alias to <code>$</code>.
 	 */
 	public static final BrowserFunctionsWithDeprecatedFunctions jQuery = $;
+	
+	private SeleniumQuery() {}
 
 	/**
 	 * <p>The seleniumQuery global browser functions object.</p>

--- a/src/main/java/io/github/seleniumquery/browser/driver/builders/DriverInstantiationUtils.java
+++ b/src/main/java/io/github/seleniumquery/browser/driver/builders/DriverInstantiationUtils.java
@@ -31,6 +31,8 @@ import static java.lang.String.format;
  * @since 0.9.0
  */
 public class DriverInstantiationUtils {
+	
+	private DriverInstantiationUtils() {}
 
 	public static String getFullPathForFileInClasspath(String executableFileName) {
 		String slashExecutableFileName = "/" + executableFileName;

--- a/src/main/java/io/github/seleniumquery/by/common/AttributeEvaluatorUtils.java
+++ b/src/main/java/io/github/seleniumquery/by/common/AttributeEvaluatorUtils.java
@@ -33,6 +33,8 @@ public class AttributeEvaluatorUtils {
      * its lowercased value.
      */
     public static final String TYPE_ATTR_LC_VAL = toLowerCase(toXPathAttribute("type"));
+    
+    private AttributeEvaluatorUtils() {}
 
     public static String getXPathAttribute(AttributeCondition attributeCondition) {
 		String attributeName = attributeCondition.getLocalName();

--- a/src/main/java/io/github/seleniumquery/by/firstgen/css/CssSelectorFactory.java
+++ b/src/main/java/io/github/seleniumquery/by/firstgen/css/CssSelectorFactory.java
@@ -40,6 +40,8 @@ public class CssSelectorFactory {
     private static final DirectDescendantCssSelector directDescendantCssSelector = new DirectDescendantCssSelector();
     private static final DirectAdjacentCssSelector directAdjacentCssSelector = new DirectAdjacentCssSelector();
     private static final GeneralAdjacentCssSelector generalAdjacentCssSelector = new GeneralAdjacentCssSelector();
+    
+    private CssSelectorFactory() {}
 
     @SuppressWarnings("unchecked")
 	public static CssSelector<Selector, TagComponent> parsedSelectorToCssSelector(Selector parsedSimpleSelector) {

--- a/src/main/java/io/github/seleniumquery/by/firstgen/css/CssSelectorMatcherService.java
+++ b/src/main/java/io/github/seleniumquery/by/firstgen/css/CssSelectorMatcherService.java
@@ -27,6 +27,8 @@ import org.w3c.css.sac.Selector;
 
 public class CssSelectorMatcherService {
 	
+	private CssSelectorMatcherService() {}
+	
 	public static boolean elementMatchesStringSelector(WebDriver driver, WebElement element, String selector) {
 		CssParsedSelectorList cssParsedSelectors = CssSelectorParser.parseSelector(selector);
 		for (CssParsedSelector cssParsedSelector : cssParsedSelectors) {

--- a/src/main/java/io/github/seleniumquery/by/firstgen/xpath/XPathComponentCompilerService.java
+++ b/src/main/java/io/github/seleniumquery/by/firstgen/xpath/XPathComponentCompilerService.java
@@ -30,6 +30,8 @@ import java.util.List;
 
 public class XPathComponentCompilerService {
 	
+	private XPathComponentCompilerService() {}
+	
 	public static TagComponentList compileSelectorList(String selector) {
 		CssParsedSelectorList parsedSelectorList = CssSelectorParser.parseSelector(selector);
 

--- a/src/main/java/io/github/seleniumquery/by/firstgen/xpath/component/ComponentUtils.java
+++ b/src/main/java/io/github/seleniumquery/by/firstgen/xpath/component/ComponentUtils.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class ComponentUtils {
+	
+	private ComponentUtils() {}
 
     public static List<XPathComponent> joinComponents(List<XPathComponent> oneComponents, XPathComponent otherCopyWithModifiedType) {
         List<XPathComponent> aggregatedComponents = new ArrayList<>(oneComponents);

--- a/src/main/java/io/github/seleniumquery/by/secondgen/finder/ElementFinderUtils.java
+++ b/src/main/java/io/github/seleniumquery/by/secondgen/finder/ElementFinderUtils.java
@@ -20,6 +20,8 @@ package io.github.seleniumquery.by.secondgen.finder;
  * Utilities for SQCss* classes.
  */
 public class ElementFinderUtils {
+	
+	private ElementFinderUtils() {}
 
     public static String conditionalSimpleXPathMerge(String leftXPathExpression, String rightXPathExpression) {
         if (leftXPathExpression == null || !leftXPathExpression.endsWith("]")) {

--- a/src/main/java/io/github/seleniumquery/by/secondgen/parser/SQParseTreeBuilder.java
+++ b/src/main/java/io/github/seleniumquery/by/secondgen/parser/SQParseTreeBuilder.java
@@ -30,6 +30,8 @@ public class SQParseTreeBuilder {
 
 	private static SQCssSelectorTranslator sqCssSelectorTranslator = new SQCssSelectorTranslator();
 	
+	private SQParseTreeBuilder() {}
+	
 	public static SQCssSelectorList parse(String selector) {
 		CssParsedSelectorList parsedSelectorList = CssSelectorParser.parseSelector(selector);
         List<SQCssSelector> cssSelectors = translate(parsedSelectorList);

--- a/src/main/java/io/github/seleniumquery/functions/jquery/attributes/AttrFunction.java
+++ b/src/main/java/io/github/seleniumquery/functions/jquery/attributes/AttrFunction.java
@@ -34,6 +34,8 @@ public class AttrFunction {
 	
 	private static final String SELECTED = "selected";
 	private static final String CHECKED = "checked";
+	
+	private AttrFunction() {}
 
 	public static String attr(SeleniumQueryObject seleniumQueryObject, String attributeName) {
         WebDriver webDriver = seleniumQueryObject.getWebDriver();

--- a/src/main/java/io/github/seleniumquery/functions/jquery/attributes/HasClassFunction.java
+++ b/src/main/java/io/github/seleniumquery/functions/jquery/attributes/HasClassFunction.java
@@ -30,6 +30,8 @@ import java.util.List;
  */
 public class HasClassFunction {
 	
+	private HasClassFunction() {}
+	
 	public static boolean hasClass(SeleniumQueryObject seleniumQueryObject, String className) {
 		List<WebElement> elements = seleniumQueryObject.get();
 		if (elements.isEmpty()) {

--- a/src/main/java/io/github/seleniumquery/functions/jquery/attributes/PropFunction.java
+++ b/src/main/java/io/github/seleniumquery/functions/jquery/attributes/PropFunction.java
@@ -32,6 +32,8 @@ import java.util.List;
  */
 public class PropFunction {
 	
+	private PropFunction() {}
+	
 	public static <T> T prop(SeleniumQueryObject seleniumQueryObject, String propertyName) {
 		List<WebElement> elements = seleniumQueryObject.get();
 		return prop(seleniumQueryObject.getWebDriver(), elements, propertyName);

--- a/src/main/java/io/github/seleniumquery/functions/jquery/attributes/RemoveAttrFunction.java
+++ b/src/main/java/io/github/seleniumquery/functions/jquery/attributes/RemoveAttrFunction.java
@@ -30,6 +30,8 @@ import java.util.List;
  */
 public class RemoveAttrFunction {
 	
+	private RemoveAttrFunction() {}
+	
 	public static SeleniumQueryObject removeAttr(SeleniumQueryObject seleniumQueryObject, String attributeNames) {
 		List<WebElement> elements = seleniumQueryObject.get();
 		JavascriptExecutor js = (JavascriptExecutor) seleniumQueryObject.getWebDriver();

--- a/src/main/java/io/github/seleniumquery/functions/jquery/events/ClickFunction.java
+++ b/src/main/java/io/github/seleniumquery/functions/jquery/events/ClickFunction.java
@@ -37,6 +37,8 @@ import static io.github.seleniumquery.functions.jquery.events.ClickFunctionUtils
 public class ClickFunction {
 
     private static final Log LOGGER = LogFactory.getLog(ClickFunction.class);
+    
+    private ClickFunction() {}
 
     public static SeleniumQueryObject click(SeleniumQueryObject seleniumQueryObject) {
         LOGGER.debug("Clicking "+seleniumQueryObject+".");

--- a/src/main/java/io/github/seleniumquery/functions/jquery/events/ClickFunctionUtils.java
+++ b/src/main/java/io/github/seleniumquery/functions/jquery/events/ClickFunctionUtils.java
@@ -26,6 +26,8 @@ import java.util.List;
 import static java.lang.String.format;
 
 class ClickFunctionUtils {
+	
+	private ClickFunctionUtils() {}
 
     static void reportIfThereWasAnyElementNotClicked(Log logger, SeleniumQueryObject seleniumQueryObject, List<WebElement> elements,
                                                      int numberOfNotClickedElements, Exception lastCaughtException, WebElement elementThatThrewLastCaughtException) {

--- a/src/main/java/io/github/seleniumquery/functions/jquery/forms/FocusFunction.java
+++ b/src/main/java/io/github/seleniumquery/functions/jquery/forms/FocusFunction.java
@@ -35,6 +35,8 @@ import java.util.List;
 public class FocusFunction {
 	
 	private static final Log LOGGER = LogFactory.getLog(FocusFunction.class);
+	
+	private FocusFunction() {}
 
 	public static SeleniumQueryObject focus(SeleniumQueryObject caller) {
 		List<WebElement> elements = caller.get();

--- a/src/main/java/io/github/seleniumquery/functions/jquery/forms/SubmitFunction.java
+++ b/src/main/java/io/github/seleniumquery/functions/jquery/forms/SubmitFunction.java
@@ -34,6 +34,8 @@ import org.openqa.selenium.WebElement;
 public class SubmitFunction {
 
     private static final Log LOGGER = LogFactory.getLog(SubmitFunction.class);
+    
+    private SubmitFunction() {}
 
     public static void submit(SeleniumQueryObject seleniumQueryObject) {
         for (WebElement webElement : seleniumQueryObject) {

--- a/src/main/java/io/github/seleniumquery/functions/jquery/forms/ValFunction.java
+++ b/src/main/java/io/github/seleniumquery/functions/jquery/forms/ValFunction.java
@@ -37,6 +37,8 @@ public class ValFunction {
 
 	private static final Log LOGGER = LogFactory.getLog(ValFunction.class);
 	
+	private ValFunction() {}
+	
 	/*
 	 * $(".selector").val();
 	 */

--- a/src/main/java/io/github/seleniumquery/functions/jquery/manipulation/HtmlFunction.java
+++ b/src/main/java/io/github/seleniumquery/functions/jquery/manipulation/HtmlFunction.java
@@ -39,6 +39,8 @@ import java.util.List;
 public class HtmlFunction {
 
 	private static final Log LOGGER = LogFactory.getLog(HtmlFunction.class);
+	
+	private HtmlFunction() {}
 
 	public static String html(SeleniumQueryObject seleniumQueryObject) {
 		return html(seleniumQueryObject.get());

--- a/src/main/java/io/github/seleniumquery/functions/jquery/manipulation/TextFunction.java
+++ b/src/main/java/io/github/seleniumquery/functions/jquery/manipulation/TextFunction.java
@@ -30,6 +30,8 @@ import java.util.List;
  */
 public class TextFunction {
 	
+	private TextFunction() {}
+	
 	public static String text(SeleniumQueryObject seleniumQueryObject) {
 		return text(seleniumQueryObject.get());
 	}

--- a/src/main/java/io/github/seleniumquery/functions/jquery/miscellaneous/GetFunction.java
+++ b/src/main/java/io/github/seleniumquery/functions/jquery/miscellaneous/GetFunction.java
@@ -20,6 +20,8 @@ public class GetFunction {
 	
 	private static final Log LOGGER = LogFactory.getLog(GetFunction.class);
 	
+	private GetFunction() {}
+	
 	public static WebElement get(SeleniumQueryObject caller, int index) {
 		List<WebElement> elements = caller.get();
 		if (elements.size() <= index) {

--- a/src/main/java/io/github/seleniumquery/functions/jquery/miscellaneous/ToArrayFunction.java
+++ b/src/main/java/io/github/seleniumquery/functions/jquery/miscellaneous/ToArrayFunction.java
@@ -22,6 +22,8 @@ import org.openqa.selenium.WebElement;
 import java.util.List;
 
 public class ToArrayFunction {
+	
+	private ToArrayFunction() {}
 
 	public static WebElement[] toArray(SeleniumQueryObject seleniumQueryObject) {
 		List<WebElement> elements = seleniumQueryObject.get();

--- a/src/main/java/io/github/seleniumquery/functions/jquery/traversing/filtering/EqFunction.java
+++ b/src/main/java/io/github/seleniumquery/functions/jquery/traversing/filtering/EqFunction.java
@@ -36,6 +36,8 @@ import java.util.List;
  */
 public class EqFunction {
 	
+	private EqFunction() {}
+	
 	public static SeleniumQueryObject eq(SeleniumQueryObject seleniumQueryObject, int index) {
 		List<WebElement> elements = seleniumQueryObject.get();
 		ArrayList<WebElement> eqElementList = new ArrayList<>();

--- a/src/main/java/io/github/seleniumquery/functions/jquery/traversing/filtering/FirstFunction.java
+++ b/src/main/java/io/github/seleniumquery/functions/jquery/traversing/filtering/FirstFunction.java
@@ -31,6 +31,8 @@ import io.github.seleniumquery.SeleniumQueryObject;
 public class FirstFunction {
 
 	private static final int FIRST_ELEMENT_INDEX = 0;
+	
+	private FirstFunction() {}
 
 	public static SeleniumQueryObject first(SeleniumQueryObject seleniumQueryObject) {
 		return EqFunction.eq(seleniumQueryObject, FIRST_ELEMENT_INDEX);

--- a/src/main/java/io/github/seleniumquery/functions/jquery/traversing/filtering/IsFunction.java
+++ b/src/main/java/io/github/seleniumquery/functions/jquery/traversing/filtering/IsFunction.java
@@ -43,6 +43,8 @@ import java.util.regex.Pattern;
 public class IsFunction {
 
 	private static final Pattern NOT_SQ_PATTERN = Pattern.compile("not-sq\\((\\d+)\\)");
+	
+	private IsFunction() {}
 
 	public static boolean is(SeleniumQueryObject seleniumQueryObject, String selector) {
 		return is(seleniumQueryObject.getWebDriver(), seleniumQueryObject.get(), selector);

--- a/src/main/java/io/github/seleniumquery/functions/jquery/traversing/filtering/LastFunction.java
+++ b/src/main/java/io/github/seleniumquery/functions/jquery/traversing/filtering/LastFunction.java
@@ -31,6 +31,8 @@ import io.github.seleniumquery.SeleniumQueryObject;
 public class LastFunction {
 
 	private static final int LAST_ELEMENT_INDEX = -1;
+	
+	private LastFunction() {}
 
 	public static SeleniumQueryObject last(SeleniumQueryObject seleniumQueryObject) {
 		return EqFunction.eq(seleniumQueryObject, LAST_ELEMENT_INDEX);

--- a/src/main/java/io/github/seleniumquery/functions/jquery/traversing/filtering/NotFunction.java
+++ b/src/main/java/io/github/seleniumquery/functions/jquery/traversing/filtering/NotFunction.java
@@ -32,6 +32,8 @@ import java.util.List;
  */
 public class NotFunction {
 	
+	private NotFunction() {}
+	
 	public static SeleniumQueryObject not(SeleniumQueryObject seleniumQueryObject, String selector) {
 		List<WebElement> elements = seleniumQueryObject.get();
 		List<WebElement> filteredElements = new ArrayList<>(elements);

--- a/src/main/java/io/github/seleniumquery/functions/jquery/traversing/treetraversal/ChildrenFunction.java
+++ b/src/main/java/io/github/seleniumquery/functions/jquery/traversing/treetraversal/ChildrenFunction.java
@@ -35,6 +35,8 @@ import java.util.List;
  * @since 0.9.0
  */
 public class ChildrenFunction {
+	
+	private ChildrenFunction() {}
 
 	public static SeleniumQueryObject children(SeleniumQueryObject caller) {
 		List<WebElement> elements = caller.get();

--- a/src/main/java/io/github/seleniumquery/functions/jquery/traversing/treetraversal/ClosestFunction.java
+++ b/src/main/java/io/github/seleniumquery/functions/jquery/traversing/treetraversal/ClosestFunction.java
@@ -33,6 +33,8 @@ import java.util.List;
  * @since 0.9.0
  */
 public class ClosestFunction {
+	
+	private ClosestFunction() {}
 
 	public static SeleniumQueryObject closest(SeleniumQueryObject caller, String selector) {
 		List<WebElement> elements = caller.get();

--- a/src/main/java/io/github/seleniumquery/functions/jquery/traversing/treetraversal/FindFunction.java
+++ b/src/main/java/io/github/seleniumquery/functions/jquery/traversing/treetraversal/FindFunction.java
@@ -32,6 +32,8 @@ import java.util.List;
  * @since 0.9.0
  */
 public class FindFunction {
+	
+	private FindFunction() {}
 
 	public static SeleniumQueryObject find(SeleniumQueryObject seleniumQueryObject, String selector) {
 		List<WebElement> elements = seleniumQueryObject.get();

--- a/src/main/java/io/github/seleniumquery/functions/jquery/traversing/treetraversal/ParentFunction.java
+++ b/src/main/java/io/github/seleniumquery/functions/jquery/traversing/treetraversal/ParentFunction.java
@@ -39,6 +39,8 @@ import java.util.Set;
 public class ParentFunction {
 
 	private static final String NO_FILTER_SELECTOR_PROVIDED = null;
+	
+	private ParentFunction() {}
 
 	public static SeleniumQueryObject parent(SeleniumQueryObject caller) {
 		return parent(caller, NO_FILTER_SELECTOR_PROVIDED);

--- a/src/main/java/io/github/seleniumquery/utils/ListUtils.java
+++ b/src/main/java/io/github/seleniumquery/utils/ListUtils.java
@@ -27,6 +27,8 @@ import java.util.List;
  * @since 0.10.0
  */
 public class ListUtils {
+	
+	private ListUtils() {}
 
     public static <T> List<T> toImmutableRandomAccessList(List<T> els) {
         return Collections.unmodifiableList(new ArrayList<>(els));

--- a/src/main/java/io/github/seleniumquery/utils/SelectorUtils.java
+++ b/src/main/java/io/github/seleniumquery/utils/SelectorUtils.java
@@ -63,6 +63,8 @@ public class SelectorUtils {
 	 * </p>
 	 */
 	public static final String ESCAPED_SLASHES = "(?<!(?:^|[^\\\\])\\\\)";
+	
+	private SelectorUtils() {}
 
 	public static WebElement parent(WebElement element) {
 		try {

--- a/src/main/java/io/github/seleniumquery/utils/WebElementUtils.java
+++ b/src/main/java/io/github/seleniumquery/utils/WebElementUtils.java
@@ -25,6 +25,8 @@ import org.openqa.selenium.WebElement;
  * @since 0.9.0
  */
 public class WebElementUtils {
+	
+	private WebElementUtils() {}
 
     public static boolean elementHasAttribute(WebElement element, String attributeName, String attributeValue) {
         return attributeValue.equalsIgnoreCase(element.getAttribute(attributeName));

--- a/src/main/java/io/github/seleniumquery/wait/evaluators/comparison/ComparisonEvaluatorUtils.java
+++ b/src/main/java/io/github/seleniumquery/wait/evaluators/comparison/ComparisonEvaluatorUtils.java
@@ -36,6 +36,8 @@ class ComparisonEvaluatorUtils {
         DECIMAL_FORMAT = (DecimalFormat) NumberFormat.getNumberInstance();
         DECIMAL_FORMAT.setParseBigDecimal(true);
     }
+    
+    private ComparisonEvaluatorUtils() {}
 
     static BigDecimal parseNumber(Object elementValue) {
         String elementValueAsString = elementValue.toString();

--- a/src/test/java/endtoend/basic/SeleniumQueryTest.java
+++ b/src/test/java/endtoend/basic/SeleniumQueryTest.java
@@ -37,11 +37,6 @@ public class SeleniumQueryTest {
     private WebElement d2;
 
     @Test
-    public void the_SeleniumQuery_constructor_should_not_throw_exception_or_do_anything_noticeable() {
-        new SeleniumQuery();
-    }
-
-    @Test
     public void $_field() {
         verifySeleniumQueryFieldAliasWorks(SeleniumQuery.$);
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed