### PR TITLE
Code quality fix - A field should not duplicate the name of its containing class.

### DIFF
--- a/src/main/java/io/github/seleniumquery/by/common/preparser/ArgumentMap.java
+++ b/src/main/java/io/github/seleniumquery/by/common/preparser/ArgumentMap.java
@@ -20,14 +20,14 @@ import java.util.Map;
 
 public class ArgumentMap {
 
-    private Map<Integer, String> argumentMap;
+    private Map<Integer, String> argsMap;
 
     ArgumentMap(Map<Integer, String> argumentMap) {
-        this.argumentMap = argumentMap;
+        this.argsMap = argumentMap;
     }
 
     public String get(int index) {
-        return argumentMap.get(index);
+        return argsMap.get(index);
     }
 
     public String get(String index) {
@@ -35,7 +35,7 @@ public class ArgumentMap {
     }
 
     public int size() {
-        return argumentMap.size();
+        return argsMap.size();
     }
 
 }

--- a/src/main/java/io/github/seleniumquery/by/common/preparser/CssParsedSelectorList.java
+++ b/src/main/java/io/github/seleniumquery/by/common/preparser/CssParsedSelectorList.java
@@ -26,12 +26,12 @@ public class CssParsedSelectorList implements Iterable<CssParsedSelector> {
 	
 	private final SelectorList selectorList;
 	private final ArgumentMap argumentMap;
-	private final List<CssParsedSelector> cssParsedSelectorList;
+	private final List<CssParsedSelector> cssParsedSelectors;
 
 	public CssParsedSelectorList(SelectorList selectorList, ArgumentMap argumentMap) {
 		this.selectorList = selectorList;
 		this.argumentMap = argumentMap;
-		this.cssParsedSelectorList = createParsedSelectorList();
+		this.cssParsedSelectors = createParsedSelectorList();
 	}
 
 	private List<CssParsedSelector> createParsedSelectorList() {
@@ -52,16 +52,16 @@ public class CssParsedSelectorList implements Iterable<CssParsedSelector> {
 	}
 
     public int size() {
-        return cssParsedSelectorList.size();
+        return cssParsedSelectors.size();
     }
 
     @Override
     public Iterator<CssParsedSelector> iterator() {
-        return cssParsedSelectorList.iterator();
+        return cssParsedSelectors.iterator();
     }
 
     public CssParsedSelector get(int index) {
-        return cssParsedSelectorList.get(index);
+        return cssParsedSelectors.get(index);
     }
 
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1700 - A field should not duplicate the name of its containing class.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1700

Please let me know if you have any questions.

Faisal Hameed