### PR TITLE
Code quality fix - Mutable fields should not be "public static". 

### DIFF
--- a/src/main/java/io/github/seleniumquery/by/firstgen/css/pseudoclasses/DisabledPseudoClass.java
+++ b/src/main/java/io/github/seleniumquery/by/firstgen/css/pseudoclasses/DisabledPseudoClass.java
@@ -48,7 +48,7 @@ public class DisabledPseudoClass implements PseudoClass<ConditionSimpleComponent
 	private static final String SELECT = "select";
 	private static final String TEXTAREA = "textarea";
 
-	public static final List<String> DISABLEABLE_TAGS = Arrays.asList(INPUT, BUTTON, OPTGROUP, OPTION, SELECT, TEXTAREA);
+	protected static final List<String> DISABLEABLE_TAGS = Arrays.asList(INPUT, BUTTON, OPTGROUP, OPTION, SELECT, TEXTAREA);
 
 	public static final String DISABLEABLE_TAGS_XPATH = "(self::" + join(DISABLEABLE_TAGS, " or self::") + ")";
     public static final String DISABLED_XPATH_CONDITION = "((@disabled and " + DISABLEABLE_TAGS_XPATH + ") or (self::option and ancestor::optgroup[@disabled]))";

--- a/src/main/java/io/github/seleniumquery/by/firstgen/css/pseudoclasses/EnabledPseudoClass.java
+++ b/src/main/java/io/github/seleniumquery/by/firstgen/css/pseudoclasses/EnabledPseudoClass.java
@@ -41,7 +41,7 @@ public class EnabledPseudoClass implements PseudoClass<ConditionSimpleComponent>
 	
 	private static final String OPTGROUP_TAG = "optgroup";
 	private static final String OPTION_TAG = "option";
-	public static final List<String> ENABLEABLE_TAGS = DisabledPseudoClass.DISABLEABLE_TAGS;
+	protected static final List<String> ENABLEABLE_TAGS = DisabledPseudoClass.DISABLEABLE_TAGS;
 	
 	public static final String ENABLED_XPATH = "(" +
             DisabledPseudoClass.DISABLEABLE_TAGS_XPATH +

--- a/src/main/java/io/github/seleniumquery/by/firstgen/css/pseudoclasses/PseudoClassFilter.java
+++ b/src/main/java/io/github/seleniumquery/by/firstgen/css/pseudoclasses/PseudoClassFilter.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 class PseudoClassFilter implements ElementFilter {
 	
-	public static final Map<String, String> STRING_MAP_NOT_USED = null;
+	protected static final Map<String, String> STRING_MAP_NOT_USED = null;
 	public static final Selector SELECTOR_NOT_USED = null;
 	public static final String PSEUDO_CLASS_VALUE_NOT_USED = null;
 	


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2386 - Mutable fields should not be "public static". 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2386

Please let me know if you have any questions.

Faisal Hameed