### PR TITLE
Multiple code quality fix-1

### DIFF
--- a/src/main/java/io/github/seleniumquery/SeleniumQueryBrowser.java
+++ b/src/main/java/io/github/seleniumquery/SeleniumQueryBrowser.java
@@ -47,17 +47,17 @@ public class SeleniumQueryBrowser {
      *
      * @since 0.9.0
      */
-    public final BrowserFunctions $ = new BrowserFunctions();
+    public static final BrowserFunctions $ = new BrowserFunctions();
 
     /**
      * <p>The seleniumQuery browser functions object.</p> This works as an alias to <code>$</code>.
      */
-    public final BrowserFunctions sQ = $;
+    public static final BrowserFunctions sQ = $;
 
     /**
      * <p>The seleniumQuery browser functions object.</p> This works as an alias to <code>$</code>.
      */
-    public final BrowserFunctions jQuery = $;
+    public static final BrowserFunctions jQuery = $;
 
     /**
      * <p>The seleniumQuery browser functions object.</p>

--- a/src/main/java/io/github/seleniumquery/functions/jquery/traversing/filtering/IsFunction.java
+++ b/src/main/java/io/github/seleniumquery/functions/jquery/traversing/filtering/IsFunction.java
@@ -55,9 +55,9 @@ public class IsFunction {
 
     public static class CompiledSelector {
 
-        private boolean emptySelector = false;
+        private boolean emptySelector;
         private List<CompiledCssSelector> compiledCssSelectors;
-        private boolean hasNegatedPresent = false;
+        private boolean hasNegatedPresent;
 
         private class CompiledCssSelector {
             public final CssSelector<Selector, TagComponent> cssSelector;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
pmd:RedundantFieldInitializer - Redundant Field Initializer. 
squid:S1170 - Public constants should be declared "static final" rather than merely "final". 
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/pmd:RedundantFieldInitializer
https://dev.eclipse.org/sonar/rules/show/squid:S1170

Please let me know if you have any questions.

Faisal Hameed
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/seleniumQuery/seleniumQuery/pull/164%23issuecomment-228650095%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/seleniumQuery/seleniumQuery/pull/164%23issuecomment-228650095%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Those%20%60SeleniumQueryBrowser%60%27s%20fields%20are%20like%20that%20by%20design.%20They%20are%20part%20of%20the%20public%20API%20%28they%20are%20this%20way%20so%20the%20methods%20are%20easier%20to%20chain%20and%20guess%29%20-%20that%27s%20why%20the%20tests%20fail.%20Maybe%20we%20should%20add%20a%20%60%40SuppressWarnings%28%5C%22squid%3AS1170%5C%22%29%60%20there.%22%2C%20%22created_at%22%3A%20%222016-06-27T04%3A07%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5091082%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/acdcjunior%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/seleniumQuery/seleniumQuery/pull/164#issuecomment-228650095'>General Comment</a></b>
- <a href='https://github.com/acdcjunior'><img border=0 src='https://avatars.githubusercontent.com/u/5091082?v=3' height=16 width=16'></a> Those `SeleniumQueryBrowser`'s fields are like that by design. They are part of the public API (they are this way so the methods are easier to chain and guess) - that's why the tests fail. Maybe we should add a `@SuppressWarnings("squid:S1170")` there.


<a href='https://www.codereviewhub.com/seleniumQuery/seleniumQuery/pull/164?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/seleniumQuery/seleniumQuery/pull/164?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/seleniumQuery/seleniumQuery/pull/164'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>