### PR TITLE
Multiple code quality fix-2

### DIFF
--- a/src/main/java/io/github/seleniumquery/by/common/elementfilter/ElementFilterList.java
+++ b/src/main/java/io/github/seleniumquery/by/common/elementfilter/ElementFilterList.java
@@ -68,7 +68,7 @@ public class ElementFilterList {
 	}
 
 	public List<WebElement> filter(WebDriver driver, List<WebElement> elements) {
-		if (this.elementFilters.size() > 0) {
+		if (!this.elementFilters.isEmpty()) {
             // TODO we are currently disabling the filter support -- we will only take it back when the system is stable
 			throw new UnsupportedOperationException("The current selector is not yet supported. Please try a simpler one.");
 		}

--- a/src/main/java/io/github/seleniumquery/by/firstgen/xpath/component/ConditionSimpleComponent.java
+++ b/src/main/java/io/github/seleniumquery/by/firstgen/xpath/component/ConditionSimpleComponent.java
@@ -29,7 +29,7 @@ import java.util.List;
  */
 public class ConditionSimpleComponent extends ConditionComponent {
 
-    private final static String EMPTY_XPATH_EXPRESSION = "";
+    private static final String EMPTY_XPATH_EXPRESSION = "";
 
     /**
      * Creates a XPath Component that is empty (has no XPath expression) and no Element Filter.

--- a/src/main/java/io/github/seleniumquery/internal/SqObject.java
+++ b/src/main/java/io/github/seleniumquery/internal/SqObject.java
@@ -42,7 +42,7 @@ import java.util.List;
  */
 class SqObject implements SeleniumQueryObject {
 	
-	public static final Log LOGGER = LogFactory.getLog(SqObject.class);
+	private static final Log LOGGER = LogFactory.getLog(SqObject.class);
 
     static final SeleniumQueryObject NOT_BUILT_BASED_ON_A_PREVIOUS_OBJECT = null;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1312 - Loggers should be "private static final" and should share a naming convention. 
squid:S1155 - Collection.isEmpty() should be used to test for emptiness. 
squid:ModifiersOrderCheck - Modifiers should be declared in the correct order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1312
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck

Please let me know if you have any questions.

Faisal Hameed