### PR TITLE
updated selenium-java and htmlunit dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ To get the latest version of seleniumQuery, add to your **`pom.xml`**:
 <dependency>
     <groupId>io.github.seleniumquery</groupId>
     <artifactId>seleniumquery</artifactId>
-    <version>0.19.0</version>
+    <version>0.19.1</version>
 </dependency>
 ```
 
@@ -1053,7 +1053,7 @@ $.driver().useInternetExplorer().withPathToIEDriverServerExe("C:\\IEDriverServer
 
 ### Available `$("selector").functions()`
 
-Check the [javadocs for our `$().functions`](https://static.javadoc.io/io.github.seleniumquery/seleniumquery/0.19.0/index.html?io/github/seleniumquery/SeleniumQueryObject.html).
+Check the [javadocs for our `$().functions`](https://static.javadoc.io/io.github.seleniumquery/seleniumquery/0.19.1/index.html?io/github/seleniumquery/SeleniumQueryObject.html).
 
 More info also in our [API wiki page](https://github.com/seleniumQuery/seleniumQuery/wiki/seleniumQuery-API).
 
@@ -1061,7 +1061,7 @@ More info also in our [API wiki page](https://github.com/seleniumQuery/seleniumQ
 
 ### Available `$.functions()`
 
-Check the [javadocs for our `$.functions`](https://static.javadoc.io/io.github.seleniumquery/seleniumquery/0.19.0/index.html?io/github/seleniumquery/browser/BrowserFunctions.html).
+Check the [javadocs for our `$.functions`](https://static.javadoc.io/io.github.seleniumquery/seleniumquery/0.19.1/index.html?io/github/seleniumquery/browser/BrowserFunctions.html).
 
 Read about our global functions in the [API wiki page](https://github.com/seleniumQuery/seleniumQuery/wiki/seleniumQuery-API).
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,9 @@ version = '0.19.0'
 description = "seleniumQuery"
 
 ext {
-    seleniumVersion = "3.11.0"
+    seleniumVersion = "3.14.0"
     htmlUnitDriverVersion = '2.30.0'
-    webDriverManagerVersion = '2.2.1'
+    webDriverManagerVersion = '2.2.5'
 }
 
 sourceCompatibility = 1.8

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.github.seleniumquery</groupId>
 	<artifactId>seleniumquery</artifactId>
-	<version>0.19.0</version>
+	<version>0.19.1</version>
 
 	<name>seleniumQuery</name>
 	<url>http://seleniumquery.github.io/</url>
@@ -31,9 +31,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <selenium-java.version>3.11.0</selenium-java.version>
+        <selenium-java.version>3.14.0</selenium-java.version>
         <htmlunit-driver.version>2.30.0</htmlunit-driver.version>
-        <webdrivermanager.version>2.2.1</webdrivermanager.version>
+        <webdrivermanager.version>2.2.5</webdrivermanager.version>
     </properties>
 
 	<dependencies>


### PR DESCRIPTION
The current version of selenium-java contains vulnerable transitive dependencies.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/seleniumQuery/seleniumQuery/pull/213?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/seleniumQuery/seleniumQuery/pull/213'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>