### PR TITLE
Overloaded method to either clear or not for existing driver when calling driver().use()

### DIFF
--- a/src/main/java/io/github/seleniumquery/browser/driver/SeleniumQueryDriver.java
+++ b/src/main/java/io/github/seleniumquery/browser/driver/SeleniumQueryDriver.java
@@ -61,6 +61,23 @@ public class SeleniumQueryDriver {
     }
 
     /**
+     * <p>
+     *     Sets the argument as the current WebDriver instance, <b>quitting the current one, if exists.</b>
+     * </p>
+     *
+     * @param driver The WebDriver instante to be set as current.
+     * @param clear either clear the current webdriver or not
+     */
+    public void use(WebDriver driver,boolean clear) {
+        if(clear){
+            quitAndClearCurrentWebDriver();
+        }
+        this.webDriver = driver;
+    }
+
+
+
+    /**
      * <p>Returns the {@link WebDriver} currently set.</p>
      * <ul>
      *     <li>

--- a/src/main/java/io/github/seleniumquery/browser/driver/SeleniumQueryDriver.java
+++ b/src/main/java/io/github/seleniumquery/browser/driver/SeleniumQueryDriver.java
@@ -50,28 +50,25 @@ public class SeleniumQueryDriver {
 
     /**
      * <p>
-     *     Sets the argument as the current WebDriver instance, <b>quitting the current one, if exists.</b>
+     *     Sets the argument as the current WebDriver instance, <b>quitting the current one, if exists.</b>.
+     *     If you do not want to quit the current driver then you can use {@link #switchTo(WebDriver driver) switchTo} instead.
      * </p>
      *
-     * @param driver The WebDriver instante to be set as current.
+     * @param driver The WebDriver instance to be set as current.
      */
     public void use(WebDriver driver) {
         quitAndClearCurrentWebDriver();
-        this.webDriver = driver;
+        switchTo(driver);
     }
 
     /**
      * <p>
-     *     Sets the argument as the current WebDriver instance, <b>quitting the current one, if exists.</b>
+     *     Sets the argument as the current WebDriver instance, <b>leaving the current driver state open, if exists.</b>
      * </p>
      *
-     * @param driver The WebDriver instante to be set as current.
-     * @param clear either clear the current webdriver or not
+     * @param driver The WebDriver instance to be set as current.
      */
-    public void use(WebDriver driver,boolean clear) {
-        if(clear){
-            quitAndClearCurrentWebDriver();
-        }
+    public void switchTo(WebDriver driver) {
         this.webDriver = driver;
     }
 


### PR DESCRIPTION
Sometime we want not to close the current webdriver and switch between the driver then we cannot just do  `$.driver().use(webDriver);` because it will automatically close the existing driver. So to make it easy we need an extra parameter for developer to either clear or not the existing driver before instantiating the new webdriver.

`$.driver().use(webDriver,false);`
